### PR TITLE
added checks and fixed small errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The user needs to first create a dedicated *working directory* for each dataset 
  │   ├── stitching_configs.yaml (optional)
  │   ├── thumbnail_configs.yaml (optional)
  │   ├── alignment_configs.yaml (optional)
- │   └── material_table.json (optional)
+ │   └── material_table.json    (optional)
  ├── stitch
  │   └── stitch_coord
  │       ├── (section_name_0).txt
@@ -59,7 +59,7 @@ Tile_0002.tif	3686	0
 Tile_0003.tif	7373	0
 Tile_0004.tif	0	3686
 Tile_0005.tif	3686	3686
-Tile_0006.tif	3686	3686
+Tile_0006.tif	7373	3686
 ```
 
 It describes a section whose raw image tiles from the microscopy are saved under the directory `/home/feabas/my_project/raw_data/s0001`. It contains 6 images of size 4096x4096 pixels, arranged on a 2-rows-by-3-columns grid with 10% overlaps. Note that in general the images do not necessarily need to be arranged in a rectilinear pattern and the image files can have arbitrary names, as long as the coordinates are as accurate as possible. Also, make sure that the fields in the coordinate files are separated by Horizontal Tab `\t`, other delimiters are currently not supported.

--- a/feabas/aligner.py
+++ b/feabas/aligner.py
@@ -155,11 +155,12 @@ class Stack:
         if section_list is None:
             if self._mesh_dir is None:
                 raise RuntimeError('mesh_dir not defined.')
-            slist = glob.glob(os.path.join(self._mesh_dir, '*.h5'))
+            mesh_regex = os. path. abspath(os.path.join(self._mesh_dir, '*.h5'))
+            slist = glob.glob(mesh_regex)
             if bool(slist):
                 section_list = sorted([os.path.basename(s).replace('.h5', '') for s in slist])
             else:
-                raise RuntimeError('no section found.')
+                raise RuntimeError(f'no section found. looked in {mesh_regex}')
             section_order_file = kwargs.get('section_order_file', os.path.join(self._mesh_dir, 'section_order.txt'))
             section_list = rearrange_section_order(section_list, section_order_file)[0]
         assert len(section_list) == len(set(section_list))

--- a/feabas/mesh.py
+++ b/feabas/mesh.py
@@ -90,7 +90,10 @@ def config_cache(gear):
                 if 'gear' in kwargs:
                     cgear = kwargs['gear']
                 else:
-                    argspec = inspect.getargspec(func)
+                    if not hasattr(inspect, 'getargspec'):
+                        argspec =  inspect.getfullargspec(func)
+                    else:
+                        argspec = inspect.getargspec(func)
                     nd = len(argspec.args) - len(argspec.defaults)
                     kwnm = argspec.args[nd:]
                     if 'gear' in kwnm:

--- a/feabas/mipmap.py
+++ b/feabas/mipmap.py
@@ -118,6 +118,7 @@ def mip_one_level(src_dir, out_dir, **kwargs):
             out_loader.to_coordinate_file(out_meta_file)
     except Exception as err:
         logger.error(f'{src_dir}: {err}')
+        raise err
         return None
     return len(rendered)
 

--- a/feabas/renderer.py
+++ b/feabas/renderer.py
@@ -470,8 +470,6 @@ class MeshRenderer:
                 self._default_fillval = 0
         return self._default_fillval
 
-
-
 def render_whole_mesh(mesh, image_loader, prefix, **kwargs):
     driver = kwargs.get('driver', 'image')
     num_workers = kwargs.pop('num_workers', 1)
@@ -623,9 +621,9 @@ def render_whole_mesh(mesh, image_loader, prefix, **kwargs):
     if isinstance(image_loader, dal.AbstractImageLoader):
         image_loader = image_loader.init_dict()
     if driver == 'image':
-        target_func = partial(subprocess_render_mesh_tiles, imgloader=image_loader, **kwargs)
+        target_func = partial(subprocess_render_mesh_tiles, image_loader, **kwargs)
     else:
-        target_func = partial(subprocess_render_mesh_tiles, imgloader=image_loader, outnames=ts_specs, **kwargs)
+        target_func = partial(subprocess_render_mesh_tiles, image_loader, outnames=ts_specs, **kwargs)
     if (num_workers > 1) and (num_tiles > 1):
         num_tile_per_job = max(1, num_tiles // num_workers)
         if max_tile_per_job is not None:

--- a/scripts/align_main.py
+++ b/scripts/align_main.py
@@ -76,6 +76,7 @@ def generate_mesh_main():
     thumbnail_resolution = config.DEFAULT_RESOLUTION * (2 ** thumbnail_mip_lvl)
     thumbnail_mask_dir = os.path.join(thumbnail_dir, 'material_masks')
     match_list = glob.glob(os.path.join(thumb_match_dir, '*.h5'))
+    assert len(match_list)>0, f"must find more than one match in {os.path.abspath(thumb_match_dir)}"
     match_names = [os.path.basename(s).replace('.h5', '').split(match_name_delimiter) for s in match_list]
     secnames = set([s for pp in match_names for s in pp])
     alt_mask_dir = mesh_config.get('mask_dir', None)
@@ -421,6 +422,7 @@ if __name__ == '__main__':
         os.makedirs(match_dir, exist_ok=True)
         generate_mesh_main()
         match_list = sorted(glob.glob(os.path.join(thumb_match_dir, '*.h5')))
+        assert len(match_list)>0, f"must find more than one match in {os.path.abspath(thumb_match_dir)}"
         match_list = match_list[indx]
         if args.reverse:
             match_list = match_list[::-1]

--- a/scripts/stitch_main.py
+++ b/scripts/stitch_main.py
@@ -162,6 +162,7 @@ def render_one_section(tform_name, out_prefix, meta_name=None, **kwargs):
         resolution = renderer.resolution / scale
     render_settings['scale'] = scale
     out_prefix = out_prefix.replace('\\', '/')
+    print(f"out_prefix {out_prefix}")
     render_series = renderer.plan_render_series(tile_size, prefix=out_prefix,
         scale=scale, **kwargs)
     if use_tensorstore:
@@ -298,21 +299,28 @@ if __name__ == '__main__':
     indx = slice(stt_idx, stp_idx, step)
 
     if mode == 'rendering':
-        tform_list = sorted(glob.glob(os.path.join(mesh_dir, '*.h5')))
+        tform_regex = os.path.abspath(os.path.join(mesh_dir, '*.h5'))
+        tform_list = sorted(glob.glob(tform_regex))
+        assert len(tform_list)>0, f"tform list empty, didn't find any h5 files in {tform_regex}"
         tform_list = tform_list[indx]
         if args.reverse:
             tform_list = tform_list[::-1]
         stitch_configs.setdefault('meta_dir', render_meta_dir)
+        print(f"image_outdir {image_outdir}")
         render_main(tform_list, image_outdir, **stitch_configs)
     elif mode == 'optimization':
-        match_list = sorted(glob.glob(os.path.join(match_dir, '*.h5')))
+        match_regex = os.path.abspath(os.path.join(match_dir, '*.h5'))
+        match_list = sorted(glob.glob(match_regex))
+        assert len(match_list) > 0, f"match list couldn't find any h5 files {match_regex}"
         match_list = match_list[indx]
         if args.reverse:
             match_list = match_list[::-1]
         os.makedirs(mesh_dir, exist_ok=True)
         optmization_main(match_list, mesh_dir, **stitch_configs)
     else:
-        coord_list = sorted(glob.glob(os.path.join(coord_dir, '*.txt')))
+        coord_regex = os.path.abspath(os.path.join(coord_dir, '*.txt'))
+        coord_list = sorted(glob.glob(coord_regex))
+        assert len(coord_list) > 0, f"didn't find any txt coord files {coord_regex}"
         coord_list = coord_list[indx]
         if args.reverse:
             coord_list = coord_list[::-1]


### PR DESCRIPTION
there was a small python version incompatibility with inspect.getargspec. 
in the line target_func = partial(subprocess_render_mesh_tiles, image_loader, **kwargs)
the image_loader was passed in as a kwarg like image_loader=image_loader
but then msh_dict was passed in as an arg
so msh_dict as the first arg was interpreted as the value for image_loader and image_loader=image_loader was interpreted as a parameter for image_loader - making two inputs for image_loader for every function call