### PR TITLE
Pin numpy<2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme():
 install_requires = [
     'google-cloud-storage',
     'h5py',
-    'numpy',
+    'numpy<2',
     'opencv-python',
     'psutil',
     'pyyaml',


### PR DESCRIPTION
Numpy 2.0 was recently released and has a number of breaking changes, at least some of which I have seen affect feabas. best to pin under 2.0 until we can fix the breakages

See: https://numpy.org/devdocs/release/2.0.0-notes.html