### PR TITLE
Pin scipy<1.12 due to changes in scipy bicgstab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requires = [
     'pyyaml',
     'rtree',
     'scikit-image',
-    'scipy',
+    'scipy<1.12.0',
     'shapely>=2.0.0',
     'tensorstore<=0.1.51',
     'triangle',


### PR DESCRIPTION
Another similar version compatibility issue. It looks like the params for `bicgstab` changed from version 1.11 to 1.12 of SciPy (see docs for [version 1.11](https://docs.scipy.org/doc/scipy-1.11.4/reference/generated/scipy.sparse.linalg.bicgstab.html) and [version 1.12](https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.sparse.linalg.bicgstab.html))

Using the `tol` param [as `optimizer.optimize_linear` does](https://github.com/YuelongWu/feabas/blob/094af58bc92d85eeff1a7eca7c79b895feb72dd5/feabas/optimizer.py#L1154) breaks on SciPy>=1.12. I'm not immediately sure what the right change to use the new params would be (maybe just `tol` > `rtol` ?) , so I think it's a good idea to just pin the dependency to < 1.12 