### PR TITLE
Add explicit single-tile handling in stitching stage

### DIFF
--- a/feabas/common.py
+++ b/feabas/common.py
@@ -429,7 +429,7 @@ def find_elements_in_array(array, elements, tol=0):
 
 def numpy_to_str_ascii(ar):
     t = ar.clip(0,255).astype(np.uint8).ravel()
-    return t.tostring().decode('ascii')
+    return t.tobytes().decode('ascii')
 
 
 def str_to_numpy_ascii(s):

--- a/feabas/stitcher.py
+++ b/feabas/stitcher.py
@@ -331,6 +331,11 @@ class Stitcher:
             overlaps = self.overlaps
         else:
             overlaps = self.overlaps_without_matches
+        if self.num_tiles == 1:
+            logger.info("Single-tile section detected — skipping matching and creating identity mesh.")
+            self.matches = {}
+            self._connected_subsystem = np.array([0], dtype=np.int32)
+            return 1, False
         if overlaps.size == 0:
             logger.warning('no expected overlap, skip matching..')
             return 0, False

--- a/scripts/stitch_main.py
+++ b/scripts/stitch_main.py
@@ -68,6 +68,19 @@ def optimize_one_section(matchname, outname, **kwargs):
     mesh_sizes = mesh_settings.pop('mesh_sizes', [100, 300])
     t0 = time.time()
     stitcher = Stitcher.from_h5(matchname, load_matches=True, load_meshes=False)
+    if stitcher.num_tiles == 1:
+        logger.info(f"{bname}: single tile: generating identity transform and skipping optimization")
+        mesh_settings["border_width"] = 0.0
+        mesh_settings["soft_top"] = 1.0
+        mesh_settings["soft_top_width"] = 0.0
+        mesh_settings["soft_left"] = 1.0
+        mesh_settings["soft_left_width"] = 0.0
+        stitcher.initialize_meshes([mesh_sizes[1]], **mesh_settings)
+        stitcher.initialize_optimizer()
+        stitcher.refine_stage_positions()
+        stitcher.normalize_coordinates(**normalize_setting)
+        stitcher.save_to_h5(outname, save_matches=False, save_meshes=True)
+        return
     if stitcher.num_links == 0:
         stitcher.initialize_meshes(mesh_sizes, **mesh_settings)
         stitcher.initialize_optimizer()


### PR DESCRIPTION
This PR adds explicit support for sections that contain only a single tile. Single-tile sections do not participate in stitching but still need valid transformation data so that subsequent steps (mesh initialization, normalization, thumbnail generation, etc.) operate consistently.

1. Short-circuit matching for single-tile sections
    In ```Stitcher.dispatch_matchers```, a new branch detects ```num_tiles == 1``` and skips matching:
    - clears matches
    - sets a valid connected_subsystem label
    - returns early
 
   This avoids unnecessary matching logic for trivial sections.

2. Generate a consistent identity transform during optimization
    In ```optimize_one_section```, when ```num_tiles == 1```:
    - a mesh is initialized explicitly with parameters derived from mesh_settings
    - optimizer is initialized
    - ```refine_stage_positions()``` and ```normalize_coordinates()``` are executed
    - the resulting mesh is written to the output HDF5

3. Replace deprecated NumPy API
     numpy.ndarray.tostring is deprecated since Numpy 1.19. and was removed in 2.3
    
These additions allow FEABAS to process image stacks containing both multi-tile and single-tile sections in the same workflow. All changes are minimal and avoid modifying core optimization or matching algorithms.